### PR TITLE
Fix a bug when giving a value to the variable identity

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -43,7 +43,7 @@ resource "azurerm_cognitive_account" "this" {
   dynamic "identity" {
     for_each = var.identity != null ? [var.identity] : []
     content {
-      type         = identity.value.identity_type
+      type         = identity.value.type
       identity_ids = identity.value.identity_ids
     }
   }


### PR DESCRIPTION
Trivial: the naming in the variable was different from the naming in the `main.tf`

