### PR TITLE
Add module usage telemetry collection resource to this module

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,3 +185,21 @@ The actual applied tags would be:
   custom_prefix_yor_trace            = "a0425718-c57d-401c-a7d5-f3d88b2551a4"
 }
 ```
+
+## Telemetry Collection
+
+This module uses [terraform-provider-modtm](https://registry.terraform.io/providers/Azure/modtm/latest) to collect telemetry data. This provider is designed to assist with tracking the usage of Terraform modules. It creates a custom `modtm_telemetry` resource that gathers and sends telemetry data to a specified endpoint. The aim is to provide visibility into the lifecycle of your Terraform modules - whether they are being created, updated, or deleted. This data can be invaluable in understanding the usage patterns of your modules, identifying popular modules, and recognizing those that are no longer in use.
+
+The ModTM provider is designed with respect for data privacy and control. The only data collected and transmitted are the tags you define in module's `modtm_telemetry` resource, an uuid which represents a module instance's identifier, and the operation the module's caller is executing (Create/Update/Delete/Read). No other data from your Terraform modules or your environment is collected or transmitted.
+
+One of the primary design principles of the ModTM provider is its non-blocking nature. The provider is designed to work in a way that any network disconnectedness or errors during the telemetry data sending process will not cause a Terraform error or interrupt your Terraform operations. This makes the ModTM provider safe to use even in network-restricted or air-gaped environments.
+
+If the telemetry data cannot be sent due to network issues, the failure will be logged, but it will not affect the Terraform operation in progress(it might delay your operations for no more than 5 seconds). This ensures that your Terraform operations always run smoothly and without interruptions, regardless of the network conditions.
+
+You can turn off the telemetry collection by declaring the following `provider` block in your root module:
+
+```hcl
+provider "modtm" {
+  enabled = false
+}
+```

--- a/examples/azureopenai-private-endpoints/providers.tf
+++ b/examples/azureopenai-private-endpoints/providers.tf
@@ -7,9 +7,17 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.0"
     }
+    modtm = {
+      source  = "Azure/modtm"
+      version = ">= 0.1.8, < 1.0"
+    }
   }
 }
 
 provider "azurerm" {
   features {}
+}
+
+provider "modtm" {
+  enabled = false
 }

--- a/examples/azureopenai-public-endpoint/providers.tf
+++ b/examples/azureopenai-public-endpoint/providers.tf
@@ -7,9 +7,17 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.0"
     }
+    modtm = {
+      source  = "Azure/modtm"
+      version = ">= 0.1.8, < 1.0"
+    }
   }
 }
 
 provider "azurerm" {
   features {}
+}
+
+provider "modtm" {
+  enabled = false
 }

--- a/module_telemetry.tf
+++ b/module_telemetry.tf
@@ -1,0 +1,8 @@
+resource "modtm_telemetry" "this" {
+  tags = {
+
+  }
+  lifecycle {
+    ignore_changes = [nonce]
+  }
+}

--- a/providers.tf
+++ b/providers.tf
@@ -7,6 +7,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.0"
     }
+    modtm = {
+      source  = "Azure/modtm"
+      version = ">= 0.1.8, < 1.0"
+    }
     random = {
       source  = "hashicorp/random"
       version = ">= 3.0"


### PR DESCRIPTION
## Describe your changes

This pr added [terraform-provider-modtm](https://registry.terraform.io/providers/Azure/modtm/latest) to collect telemetry data. This provider is designed to assist with tracking the usage of Terraform modules. It creates a custom `modtm_telemetry` resource that gathers and sends telemetry data to a specified endpoint. The aim is to provide visibility into the lifecycle of your Terraform modules - whether they are being created, updated, or deleted. This data can be invaluable in understanding the usage patterns of your modules, identifying popular modules, and recognizing those that are no longer in use.

## Issue number

#000

## Checklist before requesting a review
- [ ] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

