### PR TITLE
chore: remove ephemeral number because of deprecation

### DIFF
--- a/module_telemetry.tf
+++ b/module_telemetry.tf
@@ -9,9 +9,4 @@ resource "modtm_telemetry" "this" {
     avm_yor_name             = "this"
     avm_yor_trace            = "bbfeb8dc-4a52-40ab-b156-4e709a8e867e"
   }
-  ephemeral_number = 26737
-
-  lifecycle {
-    ignore_changes = [ephemeral_number]
-  }
 }


### PR DESCRIPTION
## Describe your changes

Removing deprecated ephemeral number.

Currently Terraform outputs (since this morning):

```
No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
╷
│ Warning: Attribute Deprecated
│
│   with module.openai_service.module.rag_app.modtm_telemetry.this,
│   on .terraform/modules/openai_service.rag_app/module_telemetry.tf line 12, in resource "modtm_telemetry" "this":
│   12:   ephemeral_number = 3035
│
│ This field has been deprecated and will be removed in `v1`. Do not use it.
│
│ (and one more similar warning elsewhere)
╵
╷
│ Warning: Deprecated attribute
│
│   on .terraform/modules/openai_service.rag_app/module_telemetry.tf line 15, in resource "modtm_telemetry" "this":
│   15:     ignore_changes = [ephemeral_number]
│
│ The attribute "ephemeral_number" is deprecated. Refer to the provider documentation for details.
╵

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

```

## Issue number

## Checklist before requesting a review
- [x] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [x] I have executed pre-commit on my machine
- [x] I have passed pr-check on my machine

Thanks for your cooperation!

